### PR TITLE
Fix install fail in intro.Rmd

### DIFF
--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -415,7 +415,7 @@ profvis({
 })
 ```
 
-```{r echo=FALSE}
+```{r echo=FALSE, eval = FALSE}
 # This block loads the data from the first block and shows the correct output
 # for the readers.
 readRDS("shinyapp.rds")


### PR DESCRIPTION
intro.Rmd attempts to read shinyapp.rds and fails when attempting to install profvis. The chunk that generates shinyapp.rds is set not to eval, so I set the reading chunk to match.