### PR TITLE
Add support to control output file behavior

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -207,6 +207,11 @@ prune_expr_mismatch <- function(prof_data, expr_source) {
                  c("label", "linenum", "filename")]
   p <- unique(p)
 
+  # Allow profiles with no sources and no <exprs> to be parsed
+  if (nrow(p) == 0) {
+    return (prof_data)
+  }
+
   # Now make sure that each entry actually matches text in expr
   p$match <- NA
   for (i in seq_len(nrow(p))) {

--- a/man/profvis.Rd
+++ b/man/profvis.Rd
@@ -13,9 +13,10 @@ profvis(expr = NULL, interval = 0.01, prof_output = NULL,
 \item{interval}{Interval for profiling samples, in seconds. Values less than
 0.005 (5 ms) will probably not result in accurate timings}
 
-\item{prof_output}{Name of an Rprof output file in which to save profiling
-data. If \code{NULL} (the default), a temporary file will be used and
-automatically removed when the function exits.}
+\item{prof_output}{Name of an Rprof output file or directory in which to save
+profiling data. If \code{NULL} (the default), a temporary file will be used
+and automatically removed when the function exits. For a directory, a
+random filename is used.}
 
 \item{prof_input}{The path to an \code{\link{Rprof}} data file.  Not
 compatible with \code{expr} or \code{prof_output}.}


### PR DESCRIPTION
Minor additions to control the behavior of output files:

- Read `profvis.output_path` option to define the default output location of profiles. This option can be set through `options(profvis.output_path = "<path>")`
- Read 'profvis.keep_output` to keep the temporary profile even after profvis closes. This enables further processing by the host of profvis. This option can be set through `options(profvis.keep_output = TRUE)`
- Return the `output_path` under the widget structure to allow the host to retrieve profile names generated by profvis. This data can be accessed with `profvis(pause(1))$x$message$prof_output`
- Fix to parsing profiles that contain no sources and no `<expr>`. Hit this corner case while running:
```
Rprof("~/tmp/test.rprof")
pause(1)
Rprof(NULL)
profvis(prof_input = "~/tmp/test.rprof")
```