### PR TITLE
add author and maintainer fields to support r-2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ Authors@R: c(
     person(family = "D3 contributors", role = "ctb", comment = "D3 library"),
     person("Ivan", "Sagalaev", role = c("ctb", "cph"), comment = "highlight.js library")
     )
+Author: Winston Chang
+Maintainer: Winston Chang <winston@rstudio.com>
 Description: Interactive profiling data visualizations.
 Depends:
     R (>= 3.0)


### PR DESCRIPTION
The build machine is using R 2.11.1 which requires the `DESCRIPTION` file to contain these fields. Any chance we can merge this to avoid building from this branch?