### PR TITLE
add support to notify profvis host of source file events

### DIFF
--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -145,6 +145,18 @@ profvis = (function() {
       };
     }
 
+    function notifySourceFileMessage(d) {
+      if (window.parent.postMessage) {
+        window.parent.postMessage({
+          source: "profvis",
+          message: "sourcefile",
+          file: d.filename,
+          line: d.linenum,
+          details: ""
+        }, "*");
+      }
+    }
+
     // Generate the code table ----------------------------------------
     function generateCodeTable(el) {
       var content = d3.select(el);
@@ -229,6 +241,9 @@ profvis = (function() {
           if (highlighter.isLocked()) return;
 
           highlighter.hover(null);
+        })
+        .on("dblclick", function(d) {
+          notifySourceFileMessage(d);
         });
 
       function hideZeroTimeRows() {
@@ -902,6 +917,8 @@ profvis = (function() {
             zoom.x(scales.x);
 
             redrawZoom(250);
+
+            notifySourceFileMessage(d);
           });
 
         return cells;

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -153,7 +153,7 @@ profvis = (function() {
           file: d.filename,
           line: d.linenum,
           details: ""
-        }, "*");
+        }, window.location.origin);
       }
     }
 


### PR DESCRIPTION
Small change to allow hosts to get notified of a source file being double clicked from either: the flame graph or code table.