### PR TITLE
add support to customize print behavior and extension

### DIFF
--- a/R/profvis.R
+++ b/R/profvis.R
@@ -55,8 +55,7 @@ profvis <- function(expr = NULL, interval = 0.01, prof_output = NULL,
     # vector. Make sure it's a single string.
     expr_source <- paste(expr_source, collapse = "\n")
 
-    opt_extension <- getOption("profvis.prof_extension")
-    prof_extension <- if (!identical(opt_extension, NULL)) opt_extension else ".prof"
+    prof_extension <- getOption("profvis.prof_extension", default = ".prof")
 
     if (is.null(prof_output) && !is.null(getOption("profvis.prof_output")))
       prof_output <- getOption("profvis.prof_output")

--- a/R/profvis.R
+++ b/R/profvis.R
@@ -144,7 +144,7 @@ print.profvis <- function(x, ..., width = NULL, height = NULL,
   } else {
     f <- getOption("profvis.print")
     if (is.function(f)) {
-      f(x)
+      f(x, ...)
     }
     else {
       NextMethod()

--- a/R/profvis.R
+++ b/R/profvis.R
@@ -55,17 +55,20 @@ profvis <- function(expr = NULL, interval = 0.01, prof_output = NULL,
     # vector. Make sure it's a single string.
     expr_source <- paste(expr_source, collapse = "\n")
 
+    opt_extension <- getOption("profvis.prof_extension")
+    prof_extension <- if (!identical(opt_extension, NULL)) opt_extension else ".prof"
+
     if (is.null(prof_output) && !is.null(getOption("profvis.prof_output")))
       prof_output <- getOption("profvis.prof_output")
 
     remove_on_exit <- FALSE
     if (is.null(prof_output)) {
-      prof_output <- tempfile(fileext = ".prof")
+      prof_output <- tempfile(fileext = prof_extension)
       remove_on_exit <- TRUE
     }
     else {
       if (dir.exists(prof_output))
-        prof_output <- tempfile(fileext = ".prof", tmpdir = prof_output)
+        prof_output <- tempfile(fileext = prof_extension, tmpdir = prof_output)
     }
 
     gc()
@@ -140,7 +143,13 @@ print.profvis <- function(x, ..., width = NULL, height = NULL,
   if (viewer) {
     getS3method("print", "htmlwidget")(x, ...)
   } else {
-    NextMethod()
+    f <- getOption("profvis.print")
+    if (is.function(f)) {
+      f(x)
+    }
+    else {
+      NextMethod()
+    }
   }
 }
 


### PR DESCRIPTION
Two options to complete integration with the ide:
- `profvis.print`: Allows hosts to customize the behavior of `print` (Used to open the profile pane in the ide);
- `profvis.prof_extension`: Allows hosts to customize the default extension (`.rprof` in the ide)