### PR TITLE
add message for profiles with sources not available

### DIFF
--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -372,3 +372,19 @@ table.profvis-table .timebar-cell > .timebar {
 .profvis-infobox .infobox-title {
   font-weight: bold;
 }
+
+.profvis-message {
+  width: 100%;
+  height: 100%;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  align-items: center;
+  font-family: Open Sans,Helvetica,Arial,sans-serif;
+  font-size: 12px;
+}

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -158,6 +158,13 @@ profvis = (function() {
     function generateCodeTable(el) {
       var content = d3.select(el);
 
+      if (vis.fileLineTimes.length === 0) {
+        content.append("div")
+          .attr("class", "profvis-message")
+          .append("div")
+            .text("Sources not available");
+      }
+
       // One table for each file
       var tables = content.selectAll("table")
           .data(vis.fileLineTimes)


### PR DESCRIPTION
Adds a message for profiles that have no sources available:

<img width="1440" alt="screen shot 2016-03-09 at 9 19 05 am" src="https://cloud.githubusercontent.com/assets/3478847/13644101/e603a872-e5d8-11e5-9d7c-d8330a38f3a7.png">
