### PR TITLE
add tooltip to describe role of execution percentage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profvis
 Title: Visualize profiling data
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(
     person("Chang", "Winston", email = "winston@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = "cph"),

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -17,7 +17,7 @@ profvis = (function() {
     function generateStatusBarButton(caption) {
       var spacerImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAAUCAYAAACnOeyiAAAAXklEQVR42mNgAIL///8zMYSGhjIDGYIMIiIMvECGMwMDN4M4kFEDUqIIZKwDMdSBjAsghj6Q8QPEMAAy/lOBoQekv4AYKkDGfgZeXl4RICOLQUtLiw3IUAJJMQIZ7AC2tU2tXJxOYgAAAABJRU5ErkJggg==';
 
-      var buttonHtml = 
+      var buttonHtml =
         '<div class="info-block result-block active"><span class="info-label">' + caption + '</span></div>' +
         '<div class="separator-block"><img class="separator-image" src="' + spacerImage + '"></div>';
 
@@ -183,9 +183,11 @@ profvis = (function() {
         .attr("class", "time")
         .text("Total");
 
+      var percentTooltip = "Percentage of total execution time";
       headerRows.append("th")
         .attr("class", "percent")
         .attr("colspan", "2")
+        .attr("title", percentTooltip)
         .text("% Proportion");
 
       // Insert each line of code
@@ -213,6 +215,7 @@ profvis = (function() {
 
       rows.append("td")
         .attr("class", "percent")
+        .attr("title", percentTooltip)
         .attr("data-pseudo-content",
               function(d) { return Math.round(d.sumTime/vis.totalTime * 100); });
 
@@ -220,6 +223,7 @@ profvis = (function() {
         .attr("class", "timebar-cell")
         .append("div")
           .attr("class", "timebar")
+          .attr("title", percentTooltip)
           .style("width", function(d) {
             return Math.round(d.propTime * 100) + "%";
           })

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -183,7 +183,7 @@ profvis = (function() {
         .attr("class", "time")
         .text("Total");
 
-      var percentTooltip = "Percentage of total execution time";
+      var percentTooltip = "Percentage of tracked execution time";
       headerRows.append("th")
         .attr("class", "percent")
         .attr("colspan", "2")

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -142,14 +142,14 @@ profvis = (function() {
       };
     }
 
-    function notifySourceFileMessage(d) {
+    function notifySourceFileMessage(d, details) {
       if (window.parent.postMessage) {
         window.parent.postMessage({
           source: "profvis",
           message: "sourcefile",
           file: d.filename,
           line: d.linenum,
-          details: ""
+          details: details
         }, window.location.origin);
       }
     }
@@ -235,6 +235,7 @@ profvis = (function() {
           // Info box is only relevant when mousing over flamegraph
           vis.infoBox.hide();
           highlighter.click(d);
+          notifySourceFileMessage(d, "select");
         })
         .on("mouseover", function(d) {
           if (highlighter.isLocked()) return;
@@ -249,7 +250,7 @@ profvis = (function() {
           highlighter.hover(null);
         })
         .on("dblclick", function(d) {
-          notifySourceFileMessage(d);
+          notifySourceFileMessage(d, "open");
         });
 
       function hideZeroTimeRows() {
@@ -892,6 +893,7 @@ profvis = (function() {
             // If it wasn't a drag, treat it as a click
             vis.infoBox.show(d);
             highlighter.click(d);
+            notifySourceFileMessage(d, "select");
           })
           .on("mouseover", function(d) {
             if (dragging) return;
@@ -931,7 +933,7 @@ profvis = (function() {
 
             redrawZoom(250);
 
-            notifySourceFileMessage(d);
+            notifySourceFileMessage(d, "open");
           });
 
         return cells;


### PR DESCRIPTION
Add tooltip to help understand users why the code panel does not necessarily need to add up to a 100%. That would be the case for a single entry point `call-stack` graph, which is not the case here.

<img width="1440" alt="screen shot 2016-03-15 at 11 20 41 am" src="https://cloud.githubusercontent.com/assets/3478847/13789171/109b1cfc-eaa0-11e5-887f-640fefb140f4.png">