### PR TITLE
add support to track the normalized sources path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profvis
 Title: Visualize profiling data
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(
     person("Chang", "Winston", email = "winston@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = "cph"),

--- a/R/parse.R
+++ b/R/parse.R
@@ -149,6 +149,12 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
       list(filename = filename, content = content)
     }, SIMPLIFY = FALSE, USE.NAMES = FALSE)
 
+  # Assign absolute paths to provide the original location when raising source events
+  file_contents <- lapply(file_contents, function(e) {
+    suppressWarnings(e$normpath <- normalizePath(e$filename))
+    return(e)
+  })
+
   list(
     prof = prof_data,
     interval = interval,

--- a/R/parse.R
+++ b/R/parse.R
@@ -120,7 +120,7 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
 
   # Trim filenames to make output a bit easier to interpret
   prof_data$filename <- trim_filenames(prof_data$filename)
-  suppressWarnings(fullpaths <- normalizePath(names(file_contents)))
+  suppressWarnings(normpaths <- normalizePath(names(file_contents)))
   names(file_contents) <- trim_filenames(names(file_contents))
 
   # Remove srcref info from the prof_data in cases where no file is present.
@@ -145,7 +145,7 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
   prof_data <- prune_expr_mismatch(prof_data, file_contents[["<expr>"]])
 
   # Convert file_contents to a format suitable for client
-  file_contents <- mapply(names(file_contents), file_contents, fullpaths,
+  file_contents <- mapply(names(file_contents), file_contents, normpaths,
     FUN = function(filename, content, normpath) {
       list(filename = filename, content = content, normpath = normpath)
     }, SIMPLIFY = FALSE, USE.NAMES = FALSE)

--- a/R/parse.R
+++ b/R/parse.R
@@ -120,6 +120,7 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
 
   # Trim filenames to make output a bit easier to interpret
   prof_data$filename <- trim_filenames(prof_data$filename)
+  suppressWarnings(fullpaths <- normalizePath(names(file_contents)))
   names(file_contents) <- trim_filenames(names(file_contents))
 
   # Remove srcref info from the prof_data in cases where no file is present.
@@ -144,16 +145,10 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
   prof_data <- prune_expr_mismatch(prof_data, file_contents[["<expr>"]])
 
   # Convert file_contents to a format suitable for client
-  file_contents <- mapply(names(file_contents), file_contents,
-    FUN = function(filename, content) {
-      list(filename = filename, content = content)
+  file_contents <- mapply(names(file_contents), file_contents, fullpaths,
+    FUN = function(filename, content, normpath) {
+      list(filename = filename, content = content, normpath = normpath)
     }, SIMPLIFY = FALSE, USE.NAMES = FALSE)
-
-  # Assign absolute paths to provide the original location when raising source events
-  file_contents <- lapply(file_contents, function(e) {
-    suppressWarnings(e$normpath <- normalizePath(e$filename))
-    return(e)
-  })
 
   list(
     prof = prof_data,

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -148,6 +148,7 @@ profvis = (function() {
           source: "profvis",
           message: "sourcefile",
           file: d.filename,
+          normpath: d.normpath,
           line: d.linenum,
           details: details
         }, window.location.origin);

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1518,9 +1518,11 @@ profvis = (function() {
       var lines = file.content.split("\n");
       var lineData = [];
       var filename = file.filename;
+      var normpath = file.normpath;
       for (var i=0; i<lines.length; i++) {
         lineData[i] = {
           filename: filename,
+          normpath: normpath,
           linenum: i + 1,
           content: lines[i],
           sumTime: 0


### PR DESCRIPTION
Paths are stored in their relative form (e.g. `~/temp/test.R`) which is fine; however, other scenarios like project sharing, require full paths to function properly. This adds a `normpath` property to `x$message$files` collection to track the normalized path (e.g. `/users/name/temp/test.R`)