### PR TITLE
fix visual issue while hiding memory and expanding data and remove treemap

### DIFF
--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -491,32 +491,6 @@ table.profvis-table .membar-right-cell > .membar {
   height: 25%;
 }
 
-.profvis-treemap {
-  top: 0px;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
-  position: absolute;
-  margin-top: 23px;
-  margin-bottom: 21px;
-  margin-right: 1px;
-  overflow: hidden;
-  font: 10px sans-serif;
-  color: #161616;
-}
-
-.profvis-treemap .node {
-  border: solid 1px white;
-  line-height: 0.95;
-  overflow: hidden;
-  position: absolute;
-  border-radius: 4px;
-}
-
-.profvis-treemap .node div {
-  padding: 6px 6px;
-}
-
 .profvis-treetable {
   top: 0px;
   bottom: 0px;

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -383,8 +383,8 @@ profvis = (function() {
       function disableScroll() {
       }
 
-      function useMemoryResults(value) {
-        d3.selectAll(".table-memory").style("display", value ? "none" : "");
+      function useMemoryResults() {
+        d3.selectAll(".table-memory").style("display", vis.hideMemory ? "none" : "");
       }
 
       return {
@@ -1589,6 +1589,8 @@ profvis = (function() {
         unorderedRows.sort(function(a,b) {
           return (a.id < b.id) ? -1 : (a.id == b.id ? 0 : 1);
         });
+
+        useMemoryResults();
       }
 
       var buildProfTable = function (profTree) {
@@ -1647,8 +1649,8 @@ profvis = (function() {
         return head.sumChildren;
       }
 
-      function useMemoryResults(value) {
-        d3.selectAll(".treetable-memory").style("display", value ? "none" : "");
+      function useMemoryResults() {
+        d3.selectAll(".treetable-memory").style("display", vis.hideMemory ? "none" : "");
       }
 
       vis.profTable = buildProfTable(vis.profTree);
@@ -1905,7 +1907,8 @@ profvis = (function() {
       enableScroll: enableScroll,
       disableScroll: disableScroll,
 
-      hideInternals: true
+      hideInternals: true,
+      hideMemory: false
     };
 
 
@@ -2036,8 +2039,9 @@ profvis = (function() {
           break;
         }
         case "memory": {
+          vis.hideMemory = checked;
           vis.activeViews.forEach(function(e) {
-            if (e.useMemoryResults) e.useMemoryResults(checked);
+            if (e.useMemoryResults) e.useMemoryResults();
           });
           break;
         }


### PR DESCRIPTION
While expanding data if the memory column is off, `<td>` elements are not hidden which causes the table to partially add back the memory column. Fix is to set the state of all memory related cells each time the data table rows are updated.

Also, removing unused code from the treemap visualization.