### PR TITLE
parse memory correctly when callstack contains colons

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -63,7 +63,12 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
   )
 
   # Split by ':' for memory header or ' ' for callstack
-  prof_data <- str_split(prof_data, "[: ]")
+  prof_data <- str_split(prof_data, " ")
+  if (has_memory) {
+    prof_data <- lapply(prof_data, function(prof_row) {
+      c(str_split(prof_row[1], ":")[[1]], prof_row[-1])
+    })
+  }
 
   # Replace empty strings with character(0); otherwise causes incorrect output
   # later.


### PR DESCRIPTION
Straightforward fix; however, this fix is on the memory parsing script which impacts any `profivs` operation. Most likely, a fix that can wait after the preview build.

**Problem**: `Rprof` files use `:` to delimit memory fields in each sample; however, some callstacks can contain `:` in their expressions. The side effect of the current code is that any entry in the callstack with `:` will get split and considered as multiple calls. So for instance the callstack `a -> b::c -> d` will be considered as `a -> b -> '' -> c - > d`. This will add empty labels to the callstack but I have not able to find any other side effects (UI still works correctly and memory gets assigned to parent nodes).

**Fix**: The fix is to first split by ` ` and then the first column by `:`. The first column contains the memory dump as `#1:#2:#3:#4:Callstack-1`, which we split by `:`, then we replace the first column from `prof_data` with the result of splitting `#1:#2:#3:#4:Callstack-1`. This splits the data per-column as the rest of the parsing script expects.