### PR TITLE
add support to display memory deallocs and allocs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profvis
 Title: Visualize profiling data
-Version: 0.1.8
+Version: 0.1.9
 Authors@R: c(
     person("Chang", "Winston", email = "winston@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = "cph"),

--- a/R/profvis.R
+++ b/R/profvis.R
@@ -24,6 +24,12 @@
 #'   vertical, or \code{"h"} for horizontal. This is the orientation of the
 #'   split bar.
 #'
+#' Note that memory allocation is only approximate due to the nature of the
+#' sampling profiler and garbage collection: when garbage collection triggers,
+#' memory allocations will be attributed to different lines of code.
+#' Using \code{torture = steps} helps prevent this, by making R trigger garbage
+#' collection afer every \code{torture} memory allocation step.
+#'
 #' @seealso \code{\link{print.profvis}} for printing options.
 #' @seealso \code{\link{Rprof}} for more information about how the profiling
 #'   data is collected.
@@ -32,7 +38,7 @@
 #' @export
 profvis <- function(expr = NULL, interval = 0.01, prof_output = NULL,
                     prof_input = NULL, width = NULL, height = NULL,
-                    split = c("v", "h"))
+                    split = c("v", "h"), torture = 0)
 {
   split <- match.arg(split)
   expr_q <- substitute(expr)
@@ -71,6 +77,12 @@ profvis <- function(expr = NULL, interval = 0.01, prof_output = NULL,
     }
 
     gc()
+
+    if (!identical(torture, 0)) {
+      gctorture2(step = torture)
+      on.exit(gctorture2(step = 0), add = TRUE)
+    }
+
     Rprof(prof_output, interval = interval, line.profiling = TRUE,
           gc.profiling = TRUE, memory.profiling = TRUE)
     on.exit(Rprof(NULL), add = TRUE)

--- a/R/profvis.R
+++ b/R/profvis.R
@@ -23,6 +23,8 @@
 #' @param split Direction of split. Either \code{"v"} (the default) for
 #'   vertical, or \code{"h"} for horizontal. This is the orientation of the
 #'   split bar.
+#' @param torture Triggers garbage collection after every \code{torture}
+#' memory allocation call.
 #'
 #' Note that memory allocation is only approximate due to the nature of the
 #' sampling profiler and garbage collection: when garbage collection triggers,

--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -647,12 +647,11 @@ table.profvis-table .membar-right-cell > .membar {
   padding-left: 0px;
   padding-right: 2px;
   text-align: right;
-  border-right: 0px;
 }
 
 .profvis-treetable .memory-info-right {
-  padding-left: 0px;
-  padding-right: 2px;
+  padding-left: 2px;
+  padding-right: 0px;
   text-align: left;
 }
 
@@ -683,7 +682,6 @@ table.profvis-table .membar-right-cell > .membar {
 
 .profvis-treetable .memory-bar-container {
   margin-right: 3px;
-  border-right: 0px;
 }
 
 .profvis-treetable .time-bar-container {

--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -316,6 +316,10 @@ table.profvis-table .memory {
   padding-right: 10px;
 }
 
+table.profvis-table .memory-right {
+  text-align: left;
+}
+
 table.profvis-table th.memory {
   text-align: center;
 }
@@ -328,7 +332,7 @@ table.profvis-table .timebar-cell {
 }
 
 table.profvis-table .timebar-cell > .timebar {
-  background-color: #444;
+  background-color: #5A5A5A;
   border-radius: 0px 2px 2px 0px;
   line-height: 15px;
 }
@@ -342,7 +346,7 @@ table.profvis-table .membar-left-cell {
 }
 
 table.profvis-table .membar-left-cell > .membar {
-  background-color: #444;
+  background-color: #BBBBBB;
   float: right;
   border-radius: 2px 0px 0px 2px;
   line-height: 15px;
@@ -350,13 +354,13 @@ table.profvis-table .membar-left-cell > .membar {
 
 table.profvis-table .membar-right-cell {
   padding-left: 0;
-  border-left: 1px solid #444;
+  border-left: 1px solid black;
   min-width: 1em;
   width: 1em;
 }
 
 table.profvis-table .membar-right-cell > .membar {
-  background-color: #444;
+  background-color: #5A5A5A;
   border-radius: 0px 2px 2px 0px;
   line-height: 15px;
 }
@@ -643,6 +647,13 @@ table.profvis-table .membar-right-cell > .membar {
   padding-left: 0px;
   padding-right: 2px;
   text-align: right;
+  border-right: 0px;
+}
+
+.profvis-treetable .memory-info-right {
+  padding-left: 0px;
+  padding-right: 2px;
+  text-align: left;
 }
 
 .profvis-treetable .memory-leftbar-wrapper {
@@ -654,7 +665,7 @@ table.profvis-table .membar-right-cell > .membar {
 .profvis-treetable .memory-leftbar {
   width: 2px;
   height: 14px;
-  background-color: #5A5A5A;
+  background-color: #BBBBBB;
   float: right;
   border-radius: 1px 0px 0px 1px;
 }
@@ -672,6 +683,7 @@ table.profvis-table .membar-right-cell > .membar {
 
 .profvis-treetable .memory-bar-container {
   margin-right: 3px;
+  border-right: 0px;
 }
 
 .profvis-treetable .time-bar-container {

--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -346,7 +346,7 @@ table.profvis-table .membar-left-cell {
 }
 
 table.profvis-table .membar-left-cell > .membar {
-  background-color: #BBBBBB;
+  background-color: #A7A7A7;
   float: right;
   border-radius: 2px 0px 0px 2px;
   line-height: 15px;
@@ -664,7 +664,7 @@ table.profvis-table .membar-right-cell > .membar {
 .profvis-treetable .memory-leftbar {
   width: 2px;
   height: 14px;
-  background-color: #BBBBBB;
+  background-color: #A7A7A7;
   float: right;
   border-radius: 1px 0px 0px 1px;
 }

--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -224,7 +224,7 @@ table.profvis-table {
 
 table.profvis-table th {
   background-color: rgb(249, 249, 250);
-  width: 12%;
+  width: 14%;
 }
 
 table.profvis-table th.spacing {
@@ -350,7 +350,7 @@ table.profvis-table .membar-left-cell > .membar {
 
 table.profvis-table .membar-right-cell {
   padding-left: 0;
-  border-left: 1px solid black;
+  border-left: 1px solid #444;
   min-width: 1em;
   width: 1em;
 }

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -222,7 +222,7 @@ profvis = (function() {
 
       headerRows.append("th")
         .attr("class", "table-memory memory")
-        .attr("colspan", "3")
+        .attr("colspan", "4")
         .text("Memory");
 
       headerRows.append("th")
@@ -254,9 +254,9 @@ profvis = (function() {
 
       rows.append("td")
         .attr("class", "table-memory memory")
-        .attr("title", "Memory deallocation / allocation (MB)")
+        .attr("title", "Memory deallocation (MB)")
         .attr("data-pseudo-content",
-              function(d) { return roundOneDecimal(d.sumMemDealloc) + " / " + roundOneDecimal(d.sumMemAlloc); });
+              function(d) { return roundOneDecimal(d.sumMemDealloc); });
 
       rows.append("td")
         .attr("class", "table-memory membar-left-cell")
@@ -279,6 +279,12 @@ profvis = (function() {
           })
           // Add the equivalent of &nbsp; to be added with CSS content
           .attr("data-pseudo-content", "\u00a0");
+
+      rows.append("td")
+        .attr("class", "table-memory memory memory-right")
+        .attr("title", "Memory allocation (MB)")
+        .attr("data-pseudo-content",
+              function(d) { return roundOneDecimal(d.sumMemAlloc); });
 
       rows.append("td")
         .attr("class", "time")
@@ -1279,7 +1285,10 @@ profvis = (function() {
       table.append("col")
         .style("width", "50px");
       table.append("col")
-        .style("width", "80px")
+        .style("width", "40px")
+        .attr("class", "treetable-memory");
+      table.append("col")
+        .style("width", "30px")
         .attr("class", "treetable-memory");
       table.append("col")
         .style("width", "40px")
@@ -1307,7 +1316,7 @@ profvis = (function() {
 
       headerRows.append("th")
         .attr("class", "treetable-memory memory")
-        .attr("colspan", "2")
+        .attr("colspan", "3")
         .text("Memory (MB)");
 
       headerRows.append("th")
@@ -1432,7 +1441,7 @@ profvis = (function() {
         newRows.append("td")
           .attr("class", "treetable-memory memory-info")
           .text(function(d) {
-            return roundOneDecimal(d.sumMemDealloc) + " / " + roundOneDecimal(d.sumMemAlloc);
+            return roundOneDecimal(d.sumMemDealloc);
           });
 
         var memoryBarContainer = newRows.append("td")
@@ -1451,6 +1460,12 @@ profvis = (function() {
           .attr("class", "memory-rightbar")
           .style("width", function(d) {
             return 1 + Math.min(Math.max(Math.round(d.propMemAlloc * 13), 0), 13) + "px";
+          });
+
+        newRows.append("td")
+          .attr("class", "treetable-memory memory-info-right")
+          .text(function(d) {
+            return roundOneDecimal(d.sumMemAlloc);
           });
 
         newRows.append("td")
@@ -1483,7 +1498,7 @@ profvis = (function() {
       var buildProfTable = function (profTree) {
         var head = jQuery.extend({}, profTree);
         var nodes = [head];
-        debugger;
+
         var aggregateChildren = function(node) {
           var nameMap = {};
           node.children.forEach(function(c) {

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -256,7 +256,7 @@ profvis = (function() {
         .attr("class", "table-memory memory")
         .attr("title", "Memory deallocation (MB)")
         .attr("data-pseudo-content",
-              function(d) { return roundOneDecimal(d.sumMemDealloc); });
+              function(d) { return roundOneDecimal(d.sumMemDealloc) != 0 ? roundOneDecimal(d.sumMemDealloc) : ""; });
 
       rows.append("td")
         .attr("class", "table-memory membar-left-cell")
@@ -284,13 +284,13 @@ profvis = (function() {
         .attr("class", "table-memory memory memory-right")
         .attr("title", "Memory allocation (MB)")
         .attr("data-pseudo-content",
-              function(d) { return roundOneDecimal(d.sumMemAlloc); });
+              function(d) { return roundOneDecimal(d.sumMemAlloc) != 0 ? roundOneDecimal(d.sumMemAlloc) : ""; });
 
       rows.append("td")
         .attr("class", "time")
         .attr("title", "Total time (ms)")
         .attr("data-pseudo-content",
-              function(d) { return (Math.round(d.sumTime * 100) / 100); });
+              function(d) { return Math.round(d.sumTime * 100) != 0 ? (Math.round(d.sumTime * 100) / 100) : ""; });
 
       rows.append("td")
         .attr("class", "timebar-cell")
@@ -1405,7 +1405,7 @@ profvis = (function() {
             table.selectAll("tr")
               .style("background-color", null);
 
-            this.style.backgroundColor = "#FDFDFD";
+            this.style.backgroundColor = "rgb(241, 241, 241)";
             notifySourceFileMessage(d, "select");
           });
 

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1285,16 +1285,16 @@ profvis = (function() {
       table.append("col")
         .style("width", "50px");
       table.append("col")
-        .style("width", "40px")
+        .style("width", "50px")
         .attr("class", "treetable-memory");
       table.append("col")
-        .style("width", "30px")
+        .style("width", "26px")
         .attr("class", "treetable-memory");
       table.append("col")
-        .style("width", "40px")
+        .style("width", "50px")
         .attr("class", "treetable-memory");
       table.append("col")
-        .style("width", "70px");
+        .style("width", "50px");
       table.append("col")
         .style("width", "40px");
 

--- a/man/print.profvis.Rd
+++ b/man/print.profvis.Rd
@@ -17,8 +17,14 @@
 \item{height}{Height of the htmlwidget}
 
 \item{split}{Direction of split. Either \code{"v"} (the default) for
-vertical, or \code{"h"} for horizontal. This is the orientation of the
-split bar.}
+  vertical, or \code{"h"} for horizontal. This is the orientation of the
+  split bar.
+
+Note that memory allocation is only approximate due to the nature of the
+sampling profiler and garbage collection: when garbage collection triggers,
+memory allocations will be attributed to different lines of code.
+Using \code{torture = steps} helps prevent this, by making R trigger garbage
+collection afer every \code{torture} memory allocation step.}
 
 \item{viewer}{If \code{FALSE} (the default), display in an external web
 browser. If \code{TRUE}, attempt to display in the RStudio viewer pane.

--- a/man/print.profvis.Rd
+++ b/man/print.profvis.Rd
@@ -17,14 +17,8 @@
 \item{height}{Height of the htmlwidget}
 
 \item{split}{Direction of split. Either \code{"v"} (the default) for
-  vertical, or \code{"h"} for horizontal. This is the orientation of the
-  split bar.
-
-Note that memory allocation is only approximate due to the nature of the
-sampling profiler and garbage collection: when garbage collection triggers,
-memory allocations will be attributed to different lines of code.
-Using \code{torture = steps} helps prevent this, by making R trigger garbage
-collection afer every \code{torture} memory allocation step.}
+vertical, or \code{"h"} for horizontal. This is the orientation of the
+split bar.}
 
 \item{viewer}{If \code{FALSE} (the default), display in an external web
 browser. If \code{TRUE}, attempt to display in the RStudio viewer pane.

--- a/man/profvis.Rd
+++ b/man/profvis.Rd
@@ -27,8 +27,11 @@ compatible with \code{expr} or \code{prof_output}.}
 \item{height}{Height of the htmlwidget}
 
 \item{split}{Direction of split. Either \code{"v"} (the default) for
-  vertical, or \code{"h"} for horizontal. This is the orientation of the
-  split bar.
+vertical, or \code{"h"} for horizontal. This is the orientation of the
+split bar.}
+
+\item{torture}{Triggers garbage collection after every \code{torture}
+memory allocation call.
 
 Note that memory allocation is only approximate due to the nature of the
 sampling profiler and garbage collection: when garbage collection triggers,

--- a/man/profvis.Rd
+++ b/man/profvis.Rd
@@ -5,7 +5,8 @@
 \title{Profile an R expression and visualize profiling data}
 \usage{
 profvis(expr = NULL, interval = 0.01, prof_output = NULL,
-  prof_input = NULL, width = NULL, height = NULL, split = c("v", "h"))
+  prof_input = NULL, width = NULL, height = NULL, split = c("v", "h"),
+  torture = 0)
 }
 \arguments{
 \item{expr}{Code to profile. Not compatible with \code{prof_input}.}
@@ -26,8 +27,14 @@ compatible with \code{expr} or \code{prof_output}.}
 \item{height}{Height of the htmlwidget}
 
 \item{split}{Direction of split. Either \code{"v"} (the default) for
-vertical, or \code{"h"} for horizontal. This is the orientation of the
-split bar.}
+  vertical, or \code{"h"} for horizontal. This is the orientation of the
+  split bar.
+
+Note that memory allocation is only approximate due to the nature of the
+sampling profiler and garbage collection: when garbage collection triggers,
+memory allocations will be attributed to different lines of code.
+Using \code{torture = steps} helps prevent this, by making R trigger garbage
+collection afer every \code{torture} memory allocation step.}
 }
 \description{
 This function will run an R expression with profiling, and then return an


### PR DESCRIPTION
This pr splits the memory column from total allocation, into allocations and deallocations.

Comment from @hadley in previous PR: "You might also want to have an example line that both allocates and frees memory - if you're not already, you should probably be aggregating allocs and frees separately." (https://github.com/rstudio/profvis/pull/39).

At that time, I was not convinced we needed to show both; however, after going through some of @wch memory profiling exercises (https://support.rstudio.com/hc/en-us/articles/218221837#additional-resources) this has become apparent.

The problem is that a lot of times memory will be allocated/deallocated on the same path/function and the profiler will only report the net allocation; it's hard to explain in the memory profiler examples why this is an issue without taking this change.

<img width="1440" alt="screen shot 2016-04-05 at 10 46 03 am" src="https://cloud.githubusercontent.com/assets/3478847/14292241/19c270aa-fb1c-11e5-9ebb-464760e91c10.png">