### PR TITLE
Improve data view for shiny usage and visual improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profvis
 Title: Visualize profiling data
-Version: 0.1.9
+Version: 0.2.0
 Authors@R: c(
     person("Chang", "Winston", email = "winston@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = "cph"),

--- a/inst/htmlwidgets/lib/profvis/profvis.css
+++ b/inst/htmlwidgets/lib/profvis/profvis.css
@@ -89,8 +89,8 @@
   border-bottom: 1px solid rgb(196, 201, 204);
   background-color: rgb(248, 249, 248);
   color: #444;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -109,8 +109,8 @@
   border-top: 1px solid rgb(196, 201, 204);
   background-color: rgb(248, 249, 248);
   color: #444;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -182,8 +182,8 @@
   padding: 3px 6px;
   border: 1px solid #999;
   background-color: #fff;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   line-height: 170%;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -215,8 +215,8 @@
 
 table.profvis-table {
   border-collapse: collapse;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   width: 100%;
   text-align: left;
   cursor: default;
@@ -453,8 +453,8 @@ table.profvis-table .membar-right-cell > .membar {
   color: #f8f8f8;
   background-color: #333;
   padding: 5px 10px;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   line-height: 100%;
   pointer-events: none;
   min-width: 280px;
@@ -486,8 +486,8 @@ table.profvis-table .membar-right-cell > .membar {
   -ms-flex-align: center;
   -webkit-align-items: center;
   align-items: center;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
 }
 
 .profvis-message div {
@@ -507,8 +507,8 @@ table.profvis-table .membar-right-cell > .membar {
   overflow: hidden;
   font: 10px sans-serif;
   color: #161616;
-  font-family: Open Sans,Helvetica,Arial,sans-serif;
-  font-size: 12px;
+  font-family: "Lucida Sans", "DejaVu Sans", "Lucida Grande", "Segoe UI", Verdana, Helvetica, sans-serif;
+  font-size: 11px;
   overflow-y: auto;
 }
 
@@ -587,6 +587,11 @@ table.profvis-table .membar-right-cell > .membar {
 
 .profvis-treetable .label-text {
   display: inline-block;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .profvis-treetable .path {

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1324,6 +1324,21 @@ profvis = (function() {
         .attr("colspan", "2")
         .text("Time (ms)");
 
+      // Retrieve all nodes (n), recursevely, where check(n) == true.
+      function allTopNodes(nodes, check) {
+        vavr included = [];
+        nodes.forEach(nodes, function(e) {
+          if (check(e))
+            included.push(e);
+        });
+        return included;
+      }
+
+      // Is there one node (n), including root, where check(n) == true?
+      function oneNode(root, check) {
+        return check(root);
+      }
+
       function updateLabelCells(labelCell) {
         labelCell
           .attr("nowrap", "true")
@@ -1336,7 +1351,9 @@ profvis = (function() {
 
             var collapsed = d.collapsed;
             if (collapsed === undefined) {
-              vis.profTable = vis.profTable.concat(d.sumChildren);
+              vis.profTable = vis.profTable.concat(allTopNodes(d.sumChildren, function(c1) {
+                return c1.depthCollapsed != null;
+              }));
               d.collapsed = false;
             }
             else if (collapsed) {
@@ -1353,7 +1370,7 @@ profvis = (function() {
             if (d.sumChildren) {
               d.sumChildren.forEach(function(c) {
                 if (c.sumChildren.length > 0)
-                  if (!vis.hideInternals || c.depthCollapsed !== null)
+                  if (!vis.hideInternals || oneNode(c, function(c1) { return c1.depthCollapsed !== null; }))
                     d.canExpand = true;
               });
             }

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1326,6 +1326,7 @@ profvis = (function() {
 
       function updateLabelCells(labelCell) {
         labelCell
+          .attr("nowrap", "true")
           .style("padding-left", function(d){
             return (8 + 15 * (d.depth - 1)) + "px";
           })

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1354,7 +1354,9 @@ profvis = (function() {
           if (check(n))
             return true;
 
-          nodes.unshift(n.sumChildren);
+          n.sumChildren.forEach(function(x) {
+            nodes.unshift(x);
+          });
         }
 
         return false;

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1313,7 +1313,8 @@ profvis = (function() {
 
       headerRows.append("th")
         .attr("class", "count")
-        .text("Calls");
+        .text("Calls")
+        .attr("title", "Calls are approximate since this is a sample-based profile")
 
       headerRows.append("th")
         .attr("class", "treetable-memory memory")


### PR DESCRIPTION
Feedback from @jcheng5:

1. Tree view causes text selection.
2. While on edge of the cell, the pointer and label start wrapping.
3. "Calls" vs "Samples"?
4. `profvis(shiny::runExample("03_reactivity"))` and data view
5. Consistent font for profvis.

Regarding (3), I meant "Calls" since it's close-enough that I believe it's useful. However, added a "Calls are approximate since this is a sample-based profile" hover message. Surprisingly, this happens to be very accurate in various situations.

Here is an update with the (4) app running:

<img width="1440" alt="screen shot 2016-04-16 at 10 38 18 pm" src="https://cloud.githubusercontent.com/assets/3478847/14584904/ecc9d35c-0423-11e6-84f7-5bfc8ff8aceb.png">