### PR TITLE
#49 display allocs and deallocs under infobox

### DIFF
--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1252,7 +1252,9 @@ profvis = (function() {
           "<tr><td class='infobox-title'>Label</td><td>" + escapeHTML(label) + "</td></tr>" +
           "<tr><td class='infobox-title'>Called from</td><td>" + escapeHTML(ref) + "</td></tr>" +
           "<tr><td class='infobox-title'>Total time</td><td>" + (d.endTime - d.startTime) + "ms</td></tr>" +
-          "<tr><td class='infobox-title'>Total memory</td><td>" + (Math.round(d.sumMem * 100) / 100) + "MB</td></tr>" +
+          "<tr><td class='infobox-title'>Total memory</td><td>" +
+            roundOneDecimal(d.sumMemDealloc) + " / " + roundOneDecimal(d.sumMemAlloc) +
+            " MB</td></tr>" +
           "<tr><td class='infobox-title'>Agg. total time</td><td>" + vis.aggLabelTimes[label] + "ms</td></tr>" +
           "<tr><td class='infobox-title'>Call stack depth</td><td>" + d.depth + "</td></tr>" +
           "</table>";
@@ -1398,7 +1400,7 @@ profvis = (function() {
               });
 
               var childNodes = sumChildren.filter(function(x) {
-                return x.depthCollapsed !== null; 
+                return x.depthCollapsed !== null;
               });
 
               childNodes.forEach(function(x) {
@@ -1407,7 +1409,7 @@ profvis = (function() {
               });
 
               var internalChildNodes = sumChildren.filter(function(x) {
-                return x.depthCollapsed === null; 
+                return x.depthCollapsed === null;
               });
 
               internalChildNodes.forEach(function(x) {

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1252,7 +1252,7 @@ profvis = (function() {
           "<tr><td class='infobox-title'>Label</td><td>" + escapeHTML(label) + "</td></tr>" +
           "<tr><td class='infobox-title'>Called from</td><td>" + escapeHTML(ref) + "</td></tr>" +
           "<tr><td class='infobox-title'>Total time</td><td>" + (d.endTime - d.startTime) + "ms</td></tr>" +
-          "<tr><td class='infobox-title'>Total memory</td><td>" +
+          "<tr><td class='infobox-title'>Memory</td><td>" +
             roundOneDecimal(d.sumMemDealloc) + " / " + roundOneDecimal(d.sumMemAlloc) +
             " MB</td></tr>" +
           "<tr><td class='infobox-title'>Agg. total time</td><td>" + vis.aggLabelTimes[label] + "ms</td></tr>" +


### PR DESCRIPTION
@wch: Adds allocs and deallocs to flame graph infobox as follows:

<img width="1440" alt="screen shot 2016-05-02 at 4 32 18 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971083/92699df4-1083-11e6-826d-78a45bbf1f89.png">

Notice that in the previous profile the flame graph and code view both match in allocs/de-allocs.

However, if more than one top-level call maps to the same line, these two numbers won't map 1:1 but adding each call should add in allocs/deallocs to the selected line in the code viewer. Consider the following profile for instance:

<img width="1440" alt="screen shot 2016-05-02 at 4 32 27 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971092/c141a27a-1083-11e6-885c-9a3d501cb617.png">

<img width="1440" alt="screen shot 2016-05-02 at 4 32 32 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971093/c14d41ac-1083-11e6-84cd-c2d2d382057b.png">
