### PR TITLE
stop tracking expressions allocation

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -82,7 +82,7 @@ parse_rprof <- function(path = "Rprof.out", expr_source = NULL) {
     memalloc <- 0
     if (has_memory) {
       # Memory is defined as: small:big:nodes:dupes
-      memalloc <- sum(as.integer(sample[1:3])) / 1024 ^ 2
+      memalloc <- sum(as.integer(sample[1:2])) / 1024 ^ 2
       sample <- sample[-4:-1]
     }
 


### PR DESCRIPTION
@hadley and @wch: I've been meaning to send this change for consideration for a while, so here it is. Would love to know your thoughts...

The way memory is tracked in `rprof` is by adding up: **big** heap objects, **small** heap objects and **expression** nodes. It's worth taking a look at `get_current_mem` from https://github.com/wch/r-source/blob/e5b21d0397c607883ff25cca379687b86933d730/src/main/memory.c#L1923

The way we calculate memory is as follows: 

```
   # Memory is defined as: small:big:nodes:dupes
   memalloc <- sum(as.integer(sample[1:3])) / 1024 ^ 2
```

This calculation tracks all the memory provided by `rprof` and also mimics the implementation from `lineprof` (see https://github.com/hadley/lineprof/blob/972e71dca0087ed8452e21f914fd612376075d5b/R/profile.R#L67)

That said, I've notice that is very unintuitive the memory allocs/dellocs caused by the expression objects (3rd paramete, from the R sources `R_NodesInUse`).

For instance, consider this profile:

```
profvis::profvis({
   profvis::pause(1)
})
```

This will cause a busy wait checking the time with a significant number of expressions being evaluated which results in this profile:

<img width="1440" alt="screen shot 2016-05-02 at 4 44 38 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971231/2e2a55fc-1085-11e6-9c19-3b357c864a2b.png">

As you can see, 394 MB were "allocated" during this busy-wait. This could be possible since, most likely, R is tracking expressions without freeing them until it exhaust the space and needs to trigger garbage collection. While this seems correct, it is unintuitive for someone that is unaware that expression evaluation causes memory allocs/deallocs.

So, the proposed change here is to stop tracking node allocations. In contrast, without tracking nodes this profile would look like this:

<img width="1440" alt="screen shot 2016-05-02 at 4 47 47 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971272/9fdc754a-1085-11e6-9e74-984a63968593.png">

Which shows only 2.3 MB allocated.

In contrast, memory-intensive applications which are allocating significant memory (aside from memory used to track expressions) would look like this without this change:

<img width="1440" alt="screen shot 2016-05-02 at 4 49 12 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971282/d0ed857a-1085-11e6-92d2-5c1a98f1c1b2.png">

But still maintain the memory-intensive results with this change since, in this case, memory is not being allocated due to the internals of expression handling:

<img width="1440" alt="screen shot 2016-05-02 at 4 50 17 pm" src="https://cloud.githubusercontent.com/assets/3478847/14971300/f9d024de-1085-11e6-933e-9fcf3a482475.png">

Not tracking memory from expressions seems more useful to me, but I'm also hesitant to show less information that what `rprof` provides.

I wonder, do you have any recollection of why `R_NodesInUse` was introduced in `lineprof` and/or `rprof`?