### PR TITLE
fix memory calculation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: profvis
 Title: Visualize profiling data
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(
     person("Chang", "Winston", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Luraschi", "Javier", email = "javier@rstudio.com", role = "aut"),


### PR DESCRIPTION
Took a look at the r-sources... while it's true that a pointer is involved, it happens to be the case that the r-sources use an union between an SEXP and a double to translate vsize into MB. This is more obvious with an example, running this:

```
profvis::profvis({
    profvis::pause(0.01)
    data <- rnorm(1024 ^ 2)
    profvis::pause(0.01)
})
```

on a x64 machines yields 8Mb, which is correct:

<img width="1269" alt="screen shot 2016-05-04 at 11 30 18 pm" src="https://cloud.githubusercontent.com/assets/3478847/15037494/8b05a1ce-1250-11e6-8689-55ab6587b4cd.png">

However, on a x86 machine, this is not the case since `.Machine$sizeof.pointer` becomes 4, but a double is still 8 bytes:

<img width="1021" alt="screen shot 2016-05-04 at 11 29 48 pm" src="https://cloud.githubusercontent.com/assets/3478847/15037536/f570be40-1250-11e6-90f3-b80ec21d0f19.png">

Therefore, seems the correct fix is to multiply this by 8 since the union contains a variable length pointer (4 - 8  bytes depending on the processor) but the double remains a double across both architectures.

Would appreciate if @wch and @hadley could take a look at the comments and sources since this has been tricky to narrow down. Thanks!