### PR TITLE
Auto-expand tree nodes in "Data" pane

### DIFF
--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1647,8 +1647,14 @@ profvis = (function() {
             childrenSum.push(nameMap[label]);
           }
 
+          // Sort by time descending
+          childrenSum.sort(function(a, b) { return b.sumTime - a.sumTime });
           return childrenSum;
         };
+
+        function addToNodesAt(c, i) {
+          nodes.splice(i, 0, c);
+        }
 
         var id = 0;
         while (nodes.length > 0) {
@@ -1658,9 +1664,9 @@ profvis = (function() {
           id = id + 1;
 
           node.sumChildren = aggregateChildren(node);
-          node.sumChildren.forEach(function(c) {
-            nodes.unshift(c);
-          });
+
+          // Processing in order is important to preserve order of IDs!
+          node.sumChildren.forEach(addToNodesAt);
         }
 
         return head.sumChildren;

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1464,7 +1464,7 @@ profvis = (function() {
           updateRows();
 
           // Nodes are sorted "heaviest first"
-          if (childNodes.length > 0) toggleTreeNode(childNodes[0]);
+          if (childNodes.length == 1) toggleTreeNode(childNodes[0]);
         }
         else {
           d.collapsed = !collapsed;

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1685,7 +1685,6 @@ profvis = (function() {
       });
 
       updateRows();
-      if (vis.profTable.length > 0) toggleTreeNode(vis.profTable[0]);
 
       return {
         el: el,

--- a/inst/htmlwidgets/lib/profvis/profvis.js
+++ b/inst/htmlwidgets/lib/profvis/profvis.js
@@ -1460,15 +1460,16 @@ profvis = (function() {
 
           vis.profTable = vis.profTable.concat(childNodes);
           d.collapsed = false;
-        }
-        else if (collapsed) {
-          d.collapsed = false;
+
+          updateRows();
+
+          // Nodes are sorted "heaviest first"
+          if (childNodes.length > 0) toggleTreeNode(childNodes[0]);
         }
         else {
-          d.collapsed = true;
+          d.collapsed = !collapsed;
+          updateRows();
         }
-
-        updateRows();
       }
 
       function updateLabelCells(labelCell) {
@@ -1684,6 +1685,7 @@ profvis = (function() {
       });
 
       updateRows();
+      if (vis.profTable.length > 0) toggleTreeNode(vis.profTable[0]);
 
       return {
         el: el,


### PR DESCRIPTION
to allow seeing the relevant details much faster.

This PR contains of two components: sorting tree nodes by time descending (commit 1), and auto-expansion (commits 2 and 3).

The auto-expansion will always expand the first node until a leaf is reached. Because the nodes are sorted by time, this will automatically focus on the most important piece of code that is likely in need of profiling.

Example run: http://rpubs.com/krlmlr/profvis-82.

Fixes #82.

Closes #50.